### PR TITLE
Fix command to export env variable

### DIFF
--- a/embedded/Dockerfile
+++ b/embedded/Dockerfile
@@ -1,6 +1,6 @@
 FROM ros:noetic-ros-base
 
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Needed to set keys
 RUN apt-get update && apt-get install software-properties-common -y


### PR DESCRIPTION
This is why we were having problems installing rtabmap in the CI : the environment variable was not correctly set.